### PR TITLE
Update to argonaut-codecs with typed errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Facilities for decoding JSON records with Argonaut
 ## Installation
 
 ```sh
-spago install purescript-tolerant-argonaut
+spago install tolerant-argonaut
 ```
 
 ## Documentation
@@ -24,14 +24,14 @@ function with behavior modeled after the standard Argonaut `decodeJson`, the sal
 Whereas `decodeJson` from [Data.Argonaut.Decode](https://pursuit.purescript.org/packages/purescript-argonaut-codecs/docs/Data.Argonaut.Decode) fails to decode a JSON object by design if the object lacks a field, `decodeJson` from [Data.Argonaut.Decode.Struct.Tolerant](https://pursuit.purescript.org/packages/purescript-tolerant-argonaut/docs/Data.Argonaut.Decode.Struct.Tolerant) interprets a field's absence, should the field have a value of a [Plus](https://pursuit.purescript.org/packages/purescript-control/docs/Control.Plus#t:Plus)-instance type, as the instance's [empty](https://pursuit.purescript.org/packages/purescript-control/docs/Control.Plus#v:empty) value.
 
 ```purescript
-import Data.Argonaut.Decode (decodeJson) as D
+import Data.Argonaut.Decode (decodeJson, JsonDecodeError) as D
 import Data.Argonaut.Decode.Struct.Tolerant (decodeJson) as T
 import Data.Argonaut.Encode (encodeJson)
 
 emptyJson = encodeJson {}
-value1 = D.decodeJson emptyJson :: Either String { a :: Maybe Int }
--- value1 == Left "JSON was missing expected field: a"
-value2 = T.decodeJson emptyJson :: Either String { a :: Maybe Int }
+value1 = D.decodeJson emptyJson :: Either D.JsonDecodeError { a :: Maybe Int }
+-- value1 == Left (AtKey "a" MissingValue)
+value2 = T.decodeJson emptyJson :: Either D.JsonDecodeError { a :: Maybe Int }
 -- value2 == Right { a: Nothing }
 ```
 
@@ -40,7 +40,7 @@ value2 = T.decodeJson emptyJson :: Either String { a :: Maybe Int }
 JSON representations of data do not always match data structures in code. [decodeJsonPer](https://pursuit.purescript.org/packages/purescript-tolerant-argonaut/docs/Data.Argonaut.Decode.Struct#v:decodeJsonPer), by default, delegates to standard [purescript-argonaut-codecs](https://pursuit.purescript.org/packages/purescript-argonaut-codecs/docs/Data.Argonaut.Decode.Class#v:decodeJson) JSON decoding. However, it also permits customized decoding of specific fields when their representation in JSON does not accord with their target representation.
 
 ```purescript
-import Data.Argonaut.Decode (decodeJson) as D
+import Data.Argonaut.Decode (decodeJson, JsonDecodeError) as D
 import Data.Argonaut.Decode.Struct (decodeJsonPer) as T
 import Data.Argonaut.Encode (encodeJson)
 
@@ -50,7 +50,7 @@ type IceCream = { flavor :: Flavor, scoops :: Scoops }
 
 jsonIceCream = encodeJson { flavor: "vanilla", scoops: 2 }
 
-iceCream :: Either String IceCream
+iceCream :: Either D.JsonDecodeError IceCream
 iceCream =
     T.decodeJsonPer
       { scoops: \scoopsJson -> convert <$> D.decodeJson scoopsJson }
@@ -68,7 +68,7 @@ iceCream =
 An example should make this clearer:
 
 ```purescript
-import Data.Argonaut.Decode (decodeJson) as D
+import Data.Argonaut.Decode (decodeJson, JsonDecodeError) as D
 import Data.Argonaut.Decode.Struct (decodeJsonWith) as T
 import Data.Argonaut.Encode (encodeJson)
 
@@ -79,7 +79,7 @@ type IceCream = { flavor :: Flavor, promotion :: Promotion, scoops :: Scoops }
 
 jsonIceCream = encodeJson { flavor: "vanilla", promotion: true, scoops: 2 }
 
-iceCream :: Either String IceCream
+iceCream :: Either D.JsonDecodeError IceCream
 iceCream =
     T.decodeJsonWith
       { scoops: \scoopsJson { promotion } ->

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Facilities for decoding JSON records with Argonaut
 
 ## Installation
 
-```shell
-bower install purescript-tolerant-argonaut
+```sh
+spago install purescript-tolerant-argonaut
 ```
 
 ## Documentation
@@ -93,4 +93,3 @@ iceCream =
 ```
 
 In the above example, all fields of a JSON object are decoded in standard fashion, except the 'scoops' field, since its decoding depends on another field of the JSON object, the 'promotion' field. As decoding for the 'promotion' field is not overridden, [decodeJsonWith](https://pursuit.purescript.org/packages/purescript-tolerant-argonaut/docs/Data.Argonaut.Decode.Struct#v:decodeJsonWith) can make the derivation of promotion data available to the customized decoder for 'scoops'.
-

--- a/bower.json
+++ b/bower.json
@@ -16,10 +16,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-argonaut-codecs": "^6.0.0",
+    "purescript-argonaut-codecs": "^7.0.0",
     "purescript-argonaut-core": "^5.0.0",
     "purescript-arrays": "^5.3.0",
-    "purescript-console": "^4.2.0",
+    "purescript-console": "^4.4.0",
     "purescript-effect": "^2.0.0",
     "purescript-higher-order": "^0.2.0",
     "purescript-lists": "^5.4.0",

--- a/bower.json
+++ b/bower.json
@@ -1,20 +1,13 @@
 {
   "name": "purescript-tolerant-argonaut",
   "homepage": "https://github.com/matthew-hilty/purescript-tolerant-argonaut",
-  "authors": [
-    "Matthew Hilty <hilty.matthew+purescript@gmail.com>"
-  ],
+  "authors": ["Matthew Hilty <hilty.matthew+purescript@gmail.com>"],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/matthew-hilty/purescript-tolerant-argonaut.git"
   },
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "output"
-  ],
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
   "dependencies": {
     "purescript-argonaut-codecs": "^7.0.0",
     "purescript-argonaut-core": "^5.0.0",
@@ -31,8 +24,5 @@
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
     "purescript-test-unit": "^15.0.0"
-  },
-  "resolutions": {
-    "purescript-typelevel-prelude": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "license": "MIT",
   "devDependencies": {
     "bower": "^1.8.8",
-    "pulp": "^13.0.0"
+    "pulp": "^15.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,58 +1,64 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/packages.dhall sha256:60cc03d2c3a99a0e5eeebb16a22aac219fa76fe6a1686e8c2bd7a11872527ea3
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
 let additions =
-  { higher-order =
-      mkPackage
-        [ "catenable-lists"
-        , "const"
-        , "effect"
-        , "errors"
-        , "generics-rep"
-        , "lists"
-        , "ordered-collections"
-        , "orders"
-        , "profunctor"
-        ]
-        "https://github.com/matthew-hilty/purescript-higher-order.git"
-        "v0.2.0"
-  , proxying =
-      mkPackage
-        [ "console"
-        , "effect"
-        , "generics-rep"
-        , "prelude"
-        , "test-unit"
-        , "typelevel-prelude"
-        ]
-        "https://github.com/matthew-hilty/purescript-proxying.git"
-        "v1.1.0"
-  , struct =
-      mkPackage
-        [ "argonaut"
-        , "argonaut-codecs"
-        , "console"
-        , "effect"
-        , "proxying"
-        , "record"
-        , "record-extra"
-        , "subcategory"
-        , "test-unit"
-        , "variant"
-        ]
-        "https://github.com/matthew-hilty/purescript-struct.git"
-        "v1.1.0"
-  , subcategory =
-      mkPackage
-        [ "prelude"
-        , "profunctor"
-        , "record"
-        ]
-        "https://github.com/matthew-hilty/purescript-subcategory.git"
-        "v0.2.0"
-  }
+      { higher-order =
+          { dependencies =
+              [ "catenable-lists"
+              , "const"
+              , "effect"
+              , "errors"
+              , "generics-rep"
+              , "lists"
+              , "ordered-collections"
+              , "orders"
+              , "profunctor"
+              ]
+          , repo =
+              "https://github.com/matthew-hilty/purescript-higher-order.git"
+          , version =
+              "v0.2.0"
+          }
+      , proxying =
+          { dependencies =
+              [ "console"
+              , "effect"
+              , "generics-rep"
+              , "prelude"
+              , "test-unit"
+              , "typelevel-prelude"
+              ]
+          , repo =
+              "https://github.com/matthew-hilty/purescript-proxying.git"
+          , version =
+              "v1.1.0"
+          }
+      , struct =
+          { dependencies =
+              [ "argonaut"
+              , "argonaut-codecs"
+              , "console"
+              , "effect"
+              , "proxying"
+              , "record"
+              , "record-extra"
+              , "subcategory"
+              , "test-unit"
+              , "variant"
+              ]
+          , repo =
+              "https://github.com/matthew-hilty/purescript-struct.git"
+          , version =
+              "v1.1.0"
+          }
+      , subcategory =
+          { dependencies =
+              [ "prelude", "profunctor", "record" ]
+          , repo =
+              "https://github.com/matthew-hilty/purescript-subcategory.git"
+          , version =
+              "v0.2.0"
+          }
+      }
 
 in  upstream // additions

--- a/src/Data/Argonaut/Decode/Struct/Cross/DecodeJsonWith.purs
+++ b/src/Data/Argonaut/Decode/Struct/Cross/DecodeJsonWith.purs
@@ -3,24 +3,15 @@ module Data.Argonaut.Decode.Struct.Cross.DecodeJsonWith
   , decodeJsonWith
   ) where
 
-import Prelude
-  ( class Bind
-  , class Category
-  , class Semigroupoid
-  , bind
-  , identity
-  , ($)
-  , (<<<)
-  )
-
 import Data.Argonaut.Core (Json)
-import Data.Argonaut.Decode.Struct.Utils (getMissingFieldErrorMessage)
+import Data.Argonaut.Decode (JsonDecodeError(..))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Operator.Bottom (class Bottom2, bottom2)
 import Data.Operator.Top (class Top1_, top1_)
 import Data.Struct (class RGet, class RInsert, rget, rinsert)
 import Data.Symbol (class IsSymbol, SProxy(SProxy), reflectSymbol)
 import Foreign.Object (Object, lookup)
+import Prelude (class Bind, class Category, class Semigroupoid, bind, identity, ($), (<<<))
 import Type.Equality (class TypeEquals, to)
 import Type.Row (class Cons, class Lacks)
 import Type.RowList (Cons, Nil, RLProxy(RLProxy), kind RowList)
@@ -59,7 +50,7 @@ instance decodeJsonWithNil
 
 instance decodeJsonWithCons
   :: ( Bind f
-     , Bottom2 f String
+     , Bottom2 f JsonDecodeError
      , Cons s fn r0' r0
      , Cons s v r3' r3
      , DecodeJsonWith p f g l0' r0' l2 r2 r3' a
@@ -80,7 +71,7 @@ instance decodeJsonWithCons
         doRest <- decodeJsonWith l0' l2 decoderStruct' object x
         top1_ $ rinsert l3' l3 s val <<< doRest
       Nothing ->
-        bottom2 $ getMissingFieldErrorMessage fieldName
+        bottom2 $ AtKey fieldName MissingValue
     where
     decoder :: Json -> a -> f v
     decoder = to $ rget l0 s decoderStruct

--- a/src/Data/Argonaut/Decode/Struct/Cross/Utils.purs
+++ b/src/Data/Argonaut/Decode/Struct/Cross/Utils.purs
@@ -2,25 +2,22 @@ module Data.Argonaut.Decode.Struct.Cross.Utils
   ( decodeJsonWith
   ) where
 
-import Prelude (class Bind, bind, ($))
-
 import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (JsonDecodeError)
 import Data.Argonaut.Decode.Class (class GDecodeJson)
-import Data.Argonaut.Decode.Struct.Cross.DecodeJsonWith
-  ( class DecodeJsonWith
-  , decodeJsonWith
-  ) as D
+import Data.Argonaut.Decode.Struct.Cross.DecodeJsonWith (class DecodeJsonWith, decodeJsonWith) as D
 import Data.Argonaut.Decode.Struct.Utils (reportJson, reportObject)
 import Data.Operator.Bottom (class Bottom2)
 import Data.Operator.Top (class Top1_, top1_)
 import Foreign.Object (Object)
+import Prelude (class Bind, bind, ($))
 import Record.Builder (Builder, build)
 import Type.RowList (class RowToList, RLProxy(RLProxy))
 
 decodeJsonWith
   :: forall f l0 l2 r0 r2 r3
    . Bind f
-  => Bottom2 f String
+  => Bottom2 f JsonDecodeError
   => D.DecodeJsonWith Builder f Record l0 r0 l2 r2 r3 (Record r2)
   => GDecodeJson r2 l2
   => RowToList r0 l0

--- a/src/Data/Argonaut/Decode/Struct/Override/DecodeJsonPer.purs
+++ b/src/Data/Argonaut/Decode/Struct/Override/DecodeJsonPer.purs
@@ -3,24 +3,15 @@ module Data.Argonaut.Decode.Struct.Override.DecodeJsonPer
   , decodeJsonPer
   ) where
 
-import Prelude
-  ( class Bind
-  , class Category
-  , class Semigroupoid
-  , bind
-  , identity
-  , ($)
-  , (<<<)
-  )
-
 import Data.Argonaut.Core (Json)
-import Data.Argonaut.Decode.Struct.Utils (getMissingFieldErrorMessage)
+import Data.Argonaut.Decode (JsonDecodeError(..))
+import Data.Maybe (Maybe(Just, Nothing))
 import Data.Operator.Bottom (class Bottom2, bottom2)
 import Data.Operator.Top (class Top1_, top1_)
-import Data.Maybe (Maybe(Just, Nothing))
 import Data.Struct (class RGet, class RInsert, rget, rinsert)
 import Data.Symbol (class IsSymbol, SProxy(SProxy), reflectSymbol)
 import Foreign.Object (Object, lookup)
+import Prelude (class Bind, class Category, class Semigroupoid, bind, identity, ($), (<<<))
 import Type.Equality (class TypeEquals, to)
 import Type.Row (class Cons, class Lacks)
 import Type.RowList (Cons, Nil, RLProxy(RLProxy), kind RowList)
@@ -57,7 +48,7 @@ instance decodeJsonPerNil
 
 instance decodeJsonPerCons
   :: ( Bind f
-     , Bottom2 f String
+     , Bottom2 f JsonDecodeError
      , Cons s fn r0' r0
      , Cons s v r2' r2
      , DecodeJsonPer p f g l0' r0' l1 r1 r2'
@@ -78,7 +69,7 @@ instance decodeJsonPerCons
         doRest <- decodeJsonPer l0' l1 decoderStruct' object
         top1_ $ rinsert l2' l2 s val <<< doRest
       Nothing ->
-        bottom2 $ getMissingFieldErrorMessage fieldName
+        bottom2 $ AtKey fieldName MissingValue
     where
     decoder :: Json -> f v
     decoder = to $ rget l0 s decoderStruct

--- a/src/Data/Argonaut/Decode/Struct/Override/Utils.purs
+++ b/src/Data/Argonaut/Decode/Struct/Override/Utils.purs
@@ -2,25 +2,22 @@ module Data.Argonaut.Decode.Struct.Override.Utils
   ( decodeJsonPer
   ) where
 
-import Prelude (class Bind, bind, ($))
-
 import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (JsonDecodeError)
 import Data.Argonaut.Decode.Class (class GDecodeJson)
-import Data.Argonaut.Decode.Struct.Override.DecodeJsonPer
-  ( class DecodeJsonPer
-  , decodeJsonPer
-  ) as D
+import Data.Argonaut.Decode.Struct.Override.DecodeJsonPer (class DecodeJsonPer, decodeJsonPer) as D
 import Data.Argonaut.Decode.Struct.Utils (reportJson, reportObject)
 import Data.Operator.Bottom (class Bottom2)
 import Data.Operator.Top (class Top1_, top1_)
 import Foreign.Object (Object)
+import Prelude (class Bind, bind, ($))
 import Record.Builder (Builder, build)
 import Type.RowList (class RowToList, RLProxy(RLProxy))
 
 decodeJsonPer
   :: forall f l0 l1 r0 r1 r2
    . Bind f
-  => Bottom2 f String
+  => Bottom2 f JsonDecodeError
   => D.DecodeJsonPer Builder f Record l0 r0 l1 r1 r2
   => GDecodeJson r1 l1
   => RowToList r0 l0

--- a/src/Data/Argonaut/Decode/Struct/Tolerant/Cross/Utils.purs
+++ b/src/Data/Argonaut/Decode/Struct/Tolerant/Cross/Utils.purs
@@ -3,32 +3,23 @@ module Data.Argonaut.Decode.Struct.Tolerant.Cross.Utils
   , decodeJsonWith
   ) where
 
-import Prelude (class Bind, bind, ($), (<<<))
-
 import Data.Argonaut.Core (Json)
-import Data.Argonaut.Decode.Struct.Cross.DecodeJsonWith
-  ( class DecodeJsonWith
-  , decodeJsonWith
-  ) as C
-import Data.Argonaut.Decode.Struct.Override.DecodeJsonPer
-  ( class DecodeJsonPer
-  , decodeJsonPer
-  ) as O
+import Data.Argonaut.Decode (JsonDecodeError)
+import Data.Argonaut.Decode.Struct.Cross.DecodeJsonWith (class DecodeJsonWith, decodeJsonWith) as C
+import Data.Argonaut.Decode.Struct.Override.DecodeJsonPer (class DecodeJsonPer, decodeJsonPer) as O
+import Data.Argonaut.Decode.Struct.Tolerant.GDecodeJson (class GDecodeJson, gDecodeJson)
 import Data.Argonaut.Decode.Struct.Utils (reportJson)
-import Data.Argonaut.Decode.Struct.Tolerant.GDecodeJson
-  ( class GDecodeJson
-  , gDecodeJson
-  )
 import Data.Operator.Bottom (class Bottom2)
 import Data.Operator.Top (class Top1_, top1_)
 import Foreign.Object (Object)
+import Prelude (class Bind, bind, ($), (<<<))
 import Record.Builder (Builder, build)
 import Type.RowList (class RowToList, Nil, RLProxy(RLProxy))
 
 decodeJsonPer
   :: forall f l0 l2 r0 r2 r3
    . Bind f
-  => Bottom2 f String
+  => Bottom2 f JsonDecodeError
   => O.DecodeJsonPer Builder f Record l0 r0 l2 r2 r3
   => GDecodeJson Builder f Record Nil () l2 r2
   => RowToList r0 l0
@@ -57,7 +48,7 @@ decodeJsonPer decoderRecord = reportJson go
 decodeJsonWith
   :: forall f l0 l2 r0 r2 r3
    . Bind f
-  => Bottom2 f String
+  => Bottom2 f JsonDecodeError
   => C.DecodeJsonWith Builder f Record l0 r0 l2 r2 r3 (Record r2)
   => GDecodeJson Builder f Record Nil () l2 r2
   => RowToList r0 l0

--- a/src/Data/Argonaut/Decode/Struct/Tolerant/DecodeJson.purs
+++ b/src/Data/Argonaut/Decode/Struct/Tolerant/DecodeJson.purs
@@ -3,27 +3,23 @@ module Data.Argonaut.Decode.Struct.Tolerant.DecodeJson
   , decodeJson
   ) where
 
-import Prelude (bind, ($))
-
 import Data.Argonaut.Core (Json, toObject)
+import Data.Argonaut.Decode (JsonDecodeError(..))
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson) as D
-import Data.Argonaut.Decode.Struct.Tolerant.GDecodeJson
-  ( class GDecodeJson
-  , gDecodeJson
-  ) as G
-import Data.Argonaut.Decode.Struct.Utils (notObjectErrorMessage)
+import Data.Argonaut.Decode.Struct.Tolerant.GDecodeJson (class GDecodeJson, gDecodeJson) as G
 import Data.Either (Either)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Operator.Bottom (bottom2)
 import Data.Operator.Top (top1_)
+import Prelude (bind, ($))
 import Record.Builder (Builder, build)
 import Type.RowList (class RowToList, Nil, RLProxy(RLProxy))
 
 class DecodeJson a where
-  decodeJson :: Json -> Either String a
+  decodeJson :: Json -> Either JsonDecodeError a
 
 instance decodeJsonRecord
-  :: ( G.GDecodeJson Builder (Either String) Record Nil () l r
+  :: ( G.GDecodeJson Builder (Either JsonDecodeError) Record Nil () l r
      , RowToList r l
      )
   => DecodeJson (Record r)
@@ -38,7 +34,7 @@ instance decodeJsonRecord
             object
         top1_ $ build builder {}
       Nothing ->
-        bottom2 notObjectErrorMessage
+        bottom2 (TypeMismatch "Object")
 
 else instance decodeDecodeJson :: D.DecodeJson a => DecodeJson a where
   decodeJson = D.decodeJson

--- a/src/Data/Argonaut/Decode/Struct/Tolerant/DecodeJson.purs
+++ b/src/Data/Argonaut/Decode/Struct/Tolerant/DecodeJson.purs
@@ -17,7 +17,7 @@ import Data.Maybe (Maybe(Just, Nothing))
 import Data.Operator.Bottom (bottom2)
 import Data.Operator.Top (top1_)
 import Record.Builder (Builder, build)
-import Type.RowList (class RowToList, Nil, RLProxy(RLProxy), kind RowList)
+import Type.RowList (class RowToList, Nil, RLProxy(RLProxy))
 
 class DecodeJson a where
   decodeJson :: Json -> Either String a

--- a/src/Data/Argonaut/Decode/Struct/Tolerant/GDecodeJson.purs
+++ b/src/Data/Argonaut/Decode/Struct/Tolerant/GDecodeJson.purs
@@ -3,12 +3,10 @@ module Data.Argonaut.Decode.Struct.Tolerant.GDecodeJson
   , gDecodeJson
   ) where
 
-import Prelude (class Category, class Semigroupoid, bind, identity, ($), (<<<))
-
 import Control.Plus (class Plus, empty)
 import Data.Argonaut.Core (Json)
+import Data.Argonaut.Decode (JsonDecodeError(..))
 import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson) as D
-import Data.Argonaut.Decode.Struct.Utils (getMissingFieldErrorMessage)
 import Data.Either (Either)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Operator.Bottom (bottom2)
@@ -16,6 +14,7 @@ import Data.Operator.Top (class Top1_, top1_)
 import Data.Struct (class RInsert, rinsert)
 import Data.Symbol (class IsSymbol, SProxy(SProxy), reflectSymbol)
 import Foreign.Object (Object, lookup)
+import Prelude (class Category, class Semigroupoid, bind, identity, ($), (<<<))
 import Type.Row (class Cons, class Lacks)
 import Type.RowList (Cons, Nil, RLProxy(RLProxy), kind RowList)
 
@@ -48,14 +47,14 @@ instance gDecodeJson_NilNilNil
 instance gDecodeJson_ConsNilCons_Plus
   :: ( Cons s (f v) r' r
      , D.DecodeJson (f v)
-     , GDecodeJson p (Either String) g Nil () l' r'
+     , GDecodeJson p (Either JsonDecodeError) g Nil () l' r'
      , IsSymbol s
      , Lacks s r'
      , Plus f
      , RInsert p g SProxy s l' r' l r
      , Semigroupoid p
      )
-  => GDecodeJson p (Either String) g Nil () (Cons s (f v) l') r
+  => GDecodeJson p (Either JsonDecodeError) g Nil () (Cons s (f v) l') r
   where
   gDecodeJson _ _ object = do
     doRest <- gDecodeJson nil l' object
@@ -77,13 +76,13 @@ instance gDecodeJson_ConsNilCons_Plus
 else instance gDecodeJson_ConsNilCons_nonPlus
   :: ( Cons s v r' r
      , D.DecodeJson v
-     , GDecodeJson p (Either String) g Nil () l' r'
+     , GDecodeJson p (Either JsonDecodeError) g Nil () l' r'
      , IsSymbol s
      , Lacks s r'
      , RInsert p g SProxy s l' r' l r
      , Semigroupoid p
      )
-  => GDecodeJson p (Either String) g Nil () (Cons s v l') r
+  => GDecodeJson p (Either JsonDecodeError) g Nil () (Cons s v l') r
   where
   gDecodeJson _ _ object = do
     case lookup fieldName object of
@@ -92,7 +91,7 @@ else instance gDecodeJson_ConsNilCons_nonPlus
         doRest <- gDecodeJson nil l' object
         top1_ $ rinsert l' l s val <<< doRest
       Nothing ->
-        bottom2 $ getMissingFieldErrorMessage fieldName
+        bottom2 $ AtKey fieldName MissingValue
     where
     fieldName :: String
     fieldName = reflectSymbol s
@@ -113,7 +112,7 @@ instance gDecodeJson_NilConsCons
 else instance gDecodeJson_ConsConsCons_Plus
   :: ( Cons s (f v) r1' r1
      , D.DecodeJson (f v)
-     , GDecodeJson p (Either String) g (Cons s1 v1 l0') r0 l1' r1'
+     , GDecodeJson p (Either JsonDecodeError) g (Cons s1 v1 l0') r0 l1' r1'
      , IsSymbol s
      , Lacks s r0
      , Lacks s r1'
@@ -121,7 +120,7 @@ else instance gDecodeJson_ConsConsCons_Plus
      , RInsert p g SProxy s l1' r1' l1 r1
      , Semigroupoid p
      )
-  => GDecodeJson p (Either String) g (Cons s1 v1 l0') r0 (Cons s (f v) l1') r1
+  => GDecodeJson p (Either JsonDecodeError) g (Cons s1 v1 l0') r0 (Cons s (f v) l1') r1
   where
   gDecodeJson _ _ object = do
     doRest <- gDecodeJson l0 l1' object
@@ -143,14 +142,14 @@ else instance gDecodeJson_ConsConsCons_Plus
 else instance gDecodeJson_ConsConsCons_nonPlus
   :: ( Cons s v r1' r1
      , D.DecodeJson v
-     , GDecodeJson p (Either String) g (Cons s1 v1 l0') r0 l1' r1'
+     , GDecodeJson p (Either JsonDecodeError) g (Cons s1 v1 l0') r0 l1' r1'
      , IsSymbol s
      , Lacks s r0
      , Lacks s r1'
      , RInsert p g SProxy s l1' r1' l1 r1
      , Semigroupoid p
      )
-  => GDecodeJson p (Either String) g (Cons s1 v1 l0') r0 (Cons s v l1') r1
+  => GDecodeJson p (Either JsonDecodeError) g (Cons s1 v1 l0') r0 (Cons s v l1') r1
   where
   gDecodeJson _ _ object = do
     case lookup fieldName object of
@@ -159,7 +158,7 @@ else instance gDecodeJson_ConsConsCons_nonPlus
         doRest <- gDecodeJson l0 l1' object
         top1_ $ rinsert l1' l1 s val <<< doRest
       Nothing ->
-        bottom2 $ getMissingFieldErrorMessage fieldName
+        bottom2 $ AtKey fieldName MissingValue
     where
     fieldName :: String
     fieldName = reflectSymbol s

--- a/src/Data/Argonaut/Decode/Struct/Utils.purs
+++ b/src/Data/Argonaut/Decode/Struct/Utils.purs
@@ -1,16 +1,11 @@
 module Data.Argonaut.Decode.Struct.Utils
-  ( elaborateFailure
-  , getMissingFieldErrorMessage
-  , notObjectErrorMessage
-  , reportJson
+  ( reportJson
   , reportObject
   ) where
 
-import Prelude
-
 import Data.Argonaut.Core (Json, toObject)
+import Data.Argonaut.Decode (JsonDecodeError(..))
 import Data.Argonaut.Decode.Class (class GDecodeJson, gDecodeJson)
-import Data.Bifunctor (lmap)
 import Data.Either (Either(Left, Right))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Operator.Bottom (class Bottom2, bottom2)
@@ -18,32 +13,20 @@ import Data.Operator.Top (class Top1_, top1_)
 import Foreign.Object (Object)
 import Type.RowList (class RowToList, RLProxy(RLProxy))
 
-elaborateFailure :: forall a. String -> Either String a -> Either String a
-elaborateFailure s e = lmap msg e
-  where
-  msg m = "Failed to decode key '" <> s <> "': " <> m
-
-getMissingFieldErrorMessage :: String -> String
-getMissingFieldErrorMessage fieldName =
-  "JSON was missing expected field: " <> fieldName
-
-notObjectErrorMessage :: String
-notObjectErrorMessage = "Could not convert JSON to object"
-
 reportJson
   :: forall a f
-   . Bottom2 f String
+   . Bottom2 f JsonDecodeError
   => (Object Json -> f a)
   -> Json
   -> f a
 reportJson f json =
   case toObject json of
     Just object -> f object
-    Nothing -> bottom2 notObjectErrorMessage
+    Nothing -> bottom2 (TypeMismatch "Object")
 
 reportObject
   :: forall f l r
-   . Bottom2 f String
+   . Bottom2 f JsonDecodeError
   => GDecodeJson r l
   => RowToList r l
   => Top1_ f
@@ -51,5 +34,5 @@ reportObject
   -> f (Record r)
 reportObject object =
   case gDecodeJson object (RLProxy :: RLProxy l) of
-    Left errorStr -> bottom2 errorStr
+    Left decodeError -> bottom2 decodeError
     Right record -> top1_ record

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -8,14 +8,13 @@ module Test.Utils
   , withErrorMsg
   ) where
 
-import Prelude (class Eq, class Show, show, (==), (<>), ($))
-
 import Data.Either (Either)
 import Data.Foldable (class Foldable, foldr)
 import Data.Maybe (Maybe(Just))
 import Data.Operator.Bottom (class Bottom2, bottom2)
 import Data.Operator.PartialOrd (class PartialOrd1, (.>=?))
 import Data.Tuple (Tuple(Tuple), uncurry)
+import Prelude (class Eq, class Show, show, (==), (<>), ($))
 import Test.Unit (Test)
 import Test.Unit.Assert as Assert
 

--- a/test/suites/Builder.purs
+++ b/test/suites/Builder.purs
@@ -2,11 +2,12 @@ module Test.Suites.Builder
   ( suites
   ) where
 
-import Prelude (discard, pure, unit, (==), ($))
-
+import Data.Argonaut.Decode (printJsonDecodeError)
 import Data.Argonaut.Decode.Struct (decodeJson')
 import Data.Argonaut.Encode (encodeJson)
+import Data.Bifunctor (lmap)
 import Data.Maybe (Maybe(Just))
+import Prelude (discard, pure, unit, (==), ($))
 import Record.Builder (build)
 import Test.Unit (TestSuite, suite, test)
 import Test.Utils (assert, checkError, withErrorMsg)
@@ -25,7 +26,7 @@ suites =
                  }
         value1 = {}
         result = decodeJson' $ encodeJson value0
-      assert $ checkError result withErrorMsg (\f -> build f value1 == value0)
+      assert $ checkError (lmap printJsonDecodeError result) withErrorMsg (\f -> build f value1 == value0)
 
     test "#1" do
       let
@@ -39,7 +40,7 @@ suites =
         result = decodeJson' $ encodeJson value0
       assert
         $ checkError
-            result
+            (lmap printJsonDecodeError result)
             withErrorMsg
             (\f -> build f value1 == { a0: value0.a0
                                      , a1: value0.a1
@@ -61,7 +62,7 @@ suites =
         result = decodeJson' $ encodeJson value0
       assert
         $ checkError
-            result
+            (lmap printJsonDecodeError result)
             withErrorMsg
             (\f -> build f value1 == { a0: value0.a0
                                      , a1: value0.a1

--- a/test/suites/Cross.purs
+++ b/test/suites/Cross.purs
@@ -4,6 +4,7 @@ module Test.Suites.Cross
 
 import Prelude
 
+import Data.Argonaut.Decode (JsonDecodeError)
 import Data.Argonaut.Decode.Struct.Cross (decodeJsonWith)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Either (Either(Right))
@@ -18,7 +19,7 @@ suites =
       let
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int
@@ -45,7 +46,7 @@ suites =
       let
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int
@@ -76,7 +77,7 @@ suites =
       let
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int
@@ -109,7 +110,7 @@ suites =
       let
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int
@@ -142,7 +143,7 @@ suites =
       let
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int
@@ -172,7 +173,7 @@ suites =
       let
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int
@@ -204,7 +205,7 @@ suites =
         isEven i = (i `mod` 2) == 0
         result
           :: Either
-              String
+              JsonDecodeError
               { a0 :: Int
               , a1 :: Int
               , a2 :: Maybe Int

--- a/test/suites/Override.purs
+++ b/test/suites/Override.purs
@@ -4,8 +4,10 @@ module Test.Suites.Override
 
 import Prelude
 
+import Data.Argonaut.Decode (JsonDecodeError(..), printJsonDecodeError)
 import Data.Argonaut.Decode.Struct.Override (decodeJsonPer)
 import Data.Argonaut.Encode (encodeJson)
+import Data.Bifunctor (lmap)
 import Data.Either (Either(Left, Right))
 import Data.Maybe (Maybe(Just))
 import Test.Unit (TestSuite, suite, test)
@@ -20,7 +22,7 @@ suites =
           suite "{ a0: 0, a1: 1, a2: Just 2 }" do
             test "Override with Just" do
               let
-                result :: Either String { a0 :: Int, a1 :: Int, a2 :: Maybe Int }
+                result :: Either JsonDecodeError { a0 :: Int, a1 :: Int, a2 :: Maybe Int }
                 result =
                   decodeJsonPer
                     { a2: \json -> Right $ Just 1002 }
@@ -33,7 +35,7 @@ suites =
             let
               result
                 :: Either
-                    String
+                    JsonDecodeError
                     { a0 :: Int
                     , a1 :: Int
                     , a2 :: Maybe Int
@@ -47,12 +49,12 @@ suites =
                   , a4: \json -> Right $ Just false
                   }
                   (encodeJson { a0: 0, a1: 1, a2: Just 2 })
-            assert $ fails result
+            assert $ fails (lmap printJsonDecodeError result)
           test "{ a0: 0, a1: 1, a2: Just 2, a3: Just \"hello\", a4: Just true }" do
             let
               result
                 :: Either
-                    String
+                    JsonDecodeError
                     { a0 :: Int
                     , a1 :: Int
                     , a2 :: Maybe Int
@@ -79,7 +81,7 @@ suites =
               let
                 result
                   :: Either
-                      String
+                      JsonDecodeError
                       { a0 :: Int
                       , a1 :: Int
                       , a2 :: Maybe Int
@@ -108,7 +110,7 @@ suites =
               let
                 result
                   :: Either
-                      String
+                      JsonDecodeError
                       { a0 :: Int
                       , a1 :: Int
                       , a2 :: Maybe Int
@@ -118,7 +120,7 @@ suites =
                 result =
                   decodeJsonPer
                     { a1: \json -> Right $ 1002
-                    , a3: \json -> Left "Capricious failure"
+                    , a3: \json -> Left MissingValue
                     }
                   (encodeJson { a0: 0
                               , a1: 1
@@ -126,14 +128,14 @@ suites =
                               , a3: Just "hello"
                               , a4: Just true
                               })
-              assert $ fails result
+              assert $ fails (lmap printJsonDecodeError result)
         suite ("Override " <> "a1, a4") do
           suite "{ a0: 0, a1: 1, a2: Just 2, a3: Just \"hello\", a4: Just true }" do
             test "#0" do
               let
                 result
                   :: Either
-                      String
+                      JsonDecodeError
                       { a0 :: Int
                       , a1 :: Int
                       , a2 :: Maybe Int
@@ -164,7 +166,7 @@ suites =
               let
                 result
                   :: Either
-                      String
+                      JsonDecodeError
                       { a0 :: Int
                       , a1 :: Int
                       , a2 :: Maybe Int

--- a/test/suites/Tolerant.purs
+++ b/test/suites/Tolerant.purs
@@ -8,6 +8,7 @@ import Control.Alt (class Alt)
 import Control.MonadZero (empty)
 import Control.Plus (class Plus)
 import Data.Argonaut.Core (Json, isNull, jsonNull)
+import Data.Argonaut.Decode (JsonDecodeError)
 import Data.Argonaut.Decode (class DecodeJson, decodeJson) as D
 import Data.Argonaut.Decode.Struct.Tolerant (decodeJson)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
@@ -87,44 +88,44 @@ suites =
         let result = decodeJson $ encodeJson value
         assertEquivalence result value
     suite "Record -- with non-Plus fields -- Should Not Compile" $ pure unit
---       test "{ a0 :: Object Json }" do
---         let value = { a0: objectValue }
---         let result = decodeJson $ encodeJson value
---         assertEquivalence result value
---       test "{ a0 :: NonEmpty Array Int }" do
---         let value = { a0: NonEmpty 0 [] }
---         let result = decodeJson $ encodeJson value
---         assertEquivalence result value
---       test "{ a0 :: NonEmpty List Int }" do
---         let value = { a0: NonEmpty 0 Nil }
---         let result = decodeJson $ encodeJson value
---         assertEquivalence result value
+      -- test "{ a0 :: Object Json }" do
+      --   let value = { a0: objectValue }
+      --   let result = decodeJson $ encodeJson value
+      --   assertEquivalence result value
+      -- test "{ a0 :: NonEmpty Array Int }" do
+      --   let value = { a0: NonEmpty 0 [] }
+      --   let result = decodeJson $ encodeJson value
+      --   assertEquivalence result value
+      -- test "{ a0 :: NonEmpty List Int }" do
+      --   let value = { a0: NonEmpty 0 Nil }
+      --   let result = decodeJson $ encodeJson value
+      --   assertEquivalence result value
     suite "Record -- with absent fields" do
       test "#0" do
         let
-          result :: Either String { a0 :: Maybe Int }
+          result :: Either JsonDecodeError { a0 :: Maybe Int }
           result = decodeJson $ encodeJson {}
         assertEquivalence result { a0: empty }
       test "#1" do
         let
-          result :: Either String { a0 :: Array Int }
+          result :: Either JsonDecodeError { a0 :: Array Int }
           result = decodeJson $ encodeJson {}
         assertEquivalence result { a0: empty }
       test "#2" do
         let
-          result :: Either String { a0 :: List Int }
+          result :: Either JsonDecodeError { a0 :: List Int }
           result = decodeJson $ encodeJson {}
         assertEquivalence result { a0: empty }
       test "#3" do
         let
-          result :: Either String { a0 :: First' Int }
+          result :: Either JsonDecodeError { a0 :: First' Int }
           result = decodeJson $ encodeJson {}
         assertEquivalence result { a0: empty }
       test "#4" do
         let
           result
             :: Either
-                  String
+                  JsonDecodeError
                   { a0 :: Maybe Int
                   , a1 :: Array Int
                   , a2 :: List Int
@@ -142,7 +143,7 @@ suites =
         let
           result
             :: Either
-                  String
+                  JsonDecodeError
                   { a00 :: Maybe String
                   , a01 :: Maybe String
                   , a03 :: String


### PR DESCRIPTION
Argonaut has updated major versions, with the `DecodeJson` and `EncodeJson` classes now using [typed errors in the latest version](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0). This PR updates this library to support the new error type. This PR is an alternative to #4.

Most of the changes involve updating usage of the `Bottom2` class to use the new error type instead of `String`. I have also updated the combinators for parity with their new versions in the argonaut-codecs library. I also removed error message helpers which are no longer needed / usable with the new typed errors.

While here, I also updated the formatting of your `spago.dhall` file as the format has changed since the one present here. The `mkPackage` utility doesn't exist anymore. I also removed the unnecessary resolution for `typelevel-eval` from the Bower file.

I tried to avoid any unnecessary refactoring, but there are a few places where my editor automatically adjusted imports, namely pulling `Prelude` down into the import list. If you would like, I can go back through and place this back at the top of the file -- or feel free to adjust this PR yourself if you would prefer. Just let me know!

I also updated the README to account for the new types, and updated the tests, and ensured that a) the tests all pass and b) the tests that shouldn't compile continue to not compile.

I _think_ this can be merged as-is to ensure compatibility with the upcoming package set release, but please let me know if you notice anything amiss.